### PR TITLE
refactor(tasks): add CacheableTask annotation

### DIFF
--- a/src/main/kotlin/io/github/grassmc/paperdev/tasks/PaperLibrariesJsonTask.kt
+++ b/src/main/kotlin/io/github/grassmc/paperdev/tasks/PaperLibrariesJsonTask.kt
@@ -24,10 +24,12 @@ import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
+@CacheableTask
 abstract class PaperLibrariesJsonTask : DefaultTask() {
     @get:Input
     abstract val librariesRootComponent: Property<ResolvedComponentResult>

--- a/src/main/kotlin/io/github/grassmc/paperdev/tasks/PaperPluginYmlTask.kt
+++ b/src/main/kotlin/io/github/grassmc/paperdev/tasks/PaperPluginYmlTask.kt
@@ -21,10 +21,12 @@ import io.github.grassmc.paperdev.utils.YamlSerializer
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
+@CacheableTask
 abstract class PaperPluginYmlTask : DefaultTask() {
     @get:Nested
     abstract val pluginYml: Property<PaperPluginYml>


### PR DESCRIPTION
This is required by the Gradle plugin validator. To clarify `The task author should make clear why a task is not cacheable.`.